### PR TITLE
fix: set default context to hooks

### DIFF
--- a/src/createMutationToolkit.ts
+++ b/src/createMutationToolkit.ts
@@ -5,6 +5,7 @@ import {
   useIsMutating,
   useMutation,
   UseMutationOptions,
+  defaultContext,
 } from "react-query";
 import { MutationFilters } from "react-query/types/core/utils";
 import { generateKey } from "./internal/generateKey";
@@ -33,6 +34,7 @@ export function createMutationToolkit(queryClient: QueryClient) {
         >,
       ) =>
         useMutation(keyGenerator(options?.mutationKey), mutationFn, {
+          context: defaultContext,
           ...defaultOptions,
           ...options,
         }),
@@ -44,7 +46,11 @@ export function createMutationToolkit(queryClient: QueryClient) {
           TMutationFnArgs,
           TContext
         >,
-      ) => useIsMutating(filters || {}, options || {}),
+      ) =>
+        useIsMutating(filters || {}, {
+          context: defaultContext,
+          ...options,
+        }),
     };
 
     return new Proxy(hooks, {

--- a/src/createQueryToolkit.ts
+++ b/src/createQueryToolkit.ts
@@ -4,6 +4,7 @@ import {
   useQuery,
   useInfiniteQuery,
   useIsFetching,
+  defaultContext,
 } from "react-query";
 import { generateKey } from "./internal/generateKey";
 import { returnByCondition } from "./internal/returnByCondition";
@@ -30,6 +31,7 @@ export function createQueryToolkit(queryClient: QueryClient): QueryCreator {
 
     const handleHooks = (hook: any) => (args?: any, queryOptions?: any) =>
       hook(getKey(queryOptions?.queryKey, args), queryFn(...(args || [])), {
+        context: defaultContext,
         ...defaultOptions,
         ...queryOptions,
       });
@@ -40,7 +42,9 @@ export function createQueryToolkit(queryClient: QueryClient): QueryCreator {
       useQuery: returnOnQuery(handleHooks(useQuery)),
       useInfiniteQuery: returnOnInfiniteQuery(handleHooks(useInfiniteQuery)),
       useIsFetching: (filters) =>
-        useIsFetching(getKey(filters?.queryKey), filters),
+        useIsFetching(getKey(filters?.queryKey), filters, {
+          context: defaultContext,
+        }),
     };
 
     const handleFetchFunctions = (


### PR DESCRIPTION
It cannot find default context automatically in next.js
resolve #18 